### PR TITLE
update readme for pytorch 1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Dependencies:
 * Python (2 or 3)
 * NumPy
 * SciPy
-* PyTorch 1.0
+* PyTorch 1.0+
 
 ## Installation using pip
 Assuming you have the listed dependencies and pip, you should be able to install.
@@ -97,7 +97,7 @@ source activate toplayer
 Now, add dependencies
 ```bash
 conda install numpy scipy matplotlib
-conda install pytorch=1.0 torchvision -c pytorch
+conda install pytorch torchvision -c pytorch
 ```
 
 Now, you can install the TopologyLayer package.
@@ -120,7 +120,7 @@ You are now ready to compile extensions.  PyTorch tutorial on extensions [here](
 *Important*: in environment, it seems like using the pytorch conda channel is important
 ```bash
 source activate toplayer
-conda install pytorch=1.0 torchvision -c pytorch
+conda install pytorch torchvision -c pytorch
 ```
 
 Compilation uses python's `setuptools` module.


### PR DESCRIPTION
All tests plus examples work on Linux using PyTorch 1.1 (current stable version)

I've updated the readme to reflect that Pytorch 1.0+ is required, and installation instructions no longer specify `pytorch=1.0`
