### PR TITLE
Allow tensors to come from GPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,10 @@ __Warning:__ 0-simplices (vertices) are assumed to start with `[0]` and end at `
 
 __Warning:__ the persistence computation currently assumes that the complex is acyclic at the end of the filtration in order to precompute the number of barcode pairs.
 
+# Note on GPU use
+
+You can use `topologylayer` with tensors that are on GPUs. However, because the persistent homology calculation takes place on CPU, there will be some overhead from memory movement.
+
 
 # (Deprecated) Dionysus Drivers
 

--- a/topologylayer/nn/alpha.py
+++ b/topologylayer/nn/alpha.py
@@ -55,7 +55,7 @@ class AlphaLayer(nn.Module):
         self.alg = alg
 
     def forward(self, x):
-        xnp = x.data.numpy()
+        xnp = x.cpu().detach().numpy()
         complex = None
         if xnp.shape[1] == 1:
             xnp = xnp.flatten()


### PR DESCRIPTION
This addresses issue #15 

The underlying problem is that the persistent homology calculation happens on the CPU.  In order to play nice with tensors on GPU, the forward/backward functions now put input tensors on CPU, then put the output back on the device the input came from.

This is backward compatible and doesn't affect behavior of tensors on CPU.

A note was added to the README describing this behavior.