### PR TITLE
Add in c++14 requirement.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Dependencies:
 * NumPy
 * SciPy
 * PyTorch 1.0+
+* C++14 compiler
 
 ## Installation using pip
 Assuming you have the listed dependencies and pip, you should be able to install.

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(name='topologylayer',
                         'topologylayer/functional/persistence/complex.cpp',
                         'topologylayer/functional/persistence/cocycle.cpp'],
                         include_dirs=[include_dir],
-                        extra_compile_args=extra['cxx']
+                        extra_compile_args=extra{"cxx": ["-std=c++14"]},
                         )
         ],
         cmdclass={'build_ext': BuildExtension},


### PR DESCRIPTION
For newer pytorch/conda installs, the current setup.py will cause the build to fail. This is because the c++ compiler must be set to use c++14.

I updated setup.py to automatically use c++14 for cxx as well as the README.md to include a c++14 compiler as a requirement.